### PR TITLE
Fixed turned zombies showing points earned when shot

### DIFF
--- a/Custom/Complete/Call of Duty Modern Warfare Remastered/your_maps_folder/scripts/zm/_zm_h1_hud.gsc
+++ b/Custom/Complete/Call of Duty Modern Warfare Remastered/your_maps_folder/scripts/zm/_zm_h1_hud.gsc
@@ -210,7 +210,7 @@ function ui_powerup_monitor()
 
 function zombie_damage_override_callback( death, inflictor, attacker, damage, flags, mod, weapon, vpoint, vdir, sHitLoc, psOffsetTime, boneIndex, surfaceType )
 {
-	if( IS_EQUAL( self.archetype, "zombie" ) )
+	if( IS_EQUAL( self.archetype, "zombie" ) && self.team == level.zombie_team)
 	{
 		if( death )
 		{

--- a/Custom/Complete/Call of Duty Vanguard/your_maps_folder/scripts/zm/_zm_s4_hud.gsc
+++ b/Custom/Complete/Call of Duty Vanguard/your_maps_folder/scripts/zm/_zm_s4_hud.gsc
@@ -210,7 +210,7 @@ function ui_powerup_monitor()
 
 function zombie_damage_override_callback( death, inflictor, attacker, damage, flags, mod, weapon, vpoint, vdir, sHitLoc, psOffsetTime, boneIndex, surfaceType )
 {
-	if( IS_EQUAL( self.archetype, "zombie" ) )
+	if( IS_EQUAL( self.archetype, "zombie" ) && self.team == level.zombie_team)
 	{
 		if( death )
 		{


### PR DESCRIPTION
Hello,

During some dev around the turned AAT I noticed the MWR HUD was having a bug so I fixed it (and the S4 one since it's the same code). Hope this helps

This issue happens on the H1 and the S4 HUDs because the check is only made on whether it's a zombie or not

Video showcasing the bug
https://drive.proton.me/urls/BCJAZXJGVC#E5vqejXA5brZ